### PR TITLE
TableBase.m fix for premature releasing of memory.  30/12/2018

### DIFF
--- a/CIXClient/src/TableBase.m
+++ b/CIXClient/src/TableBase.m
@@ -389,10 +389,10 @@
     return text;
 }
 
-NSString * getPropertyType(objc_property_t property)
+static NSString * getPropertyType(objc_property_t property)
 {
     const char *attributes = property_getAttributes(property);
-    
+
     char buffer[1 + strlen(attributes)];
     strcpy(buffer, attributes);
     char *state = buffer, *attribute;
@@ -402,13 +402,12 @@ NSString * getPropertyType(objc_property_t property)
             return [[NSString alloc] initWithBytes:(attribute + 1) length:strlen(attribute) - 1 encoding:NSUTF8StringEncoding ];
         if (attribute[0] == 'T' && attribute[1] == '@' && strlen(attribute) == 2)
             return @"id";
-        
+
         if (attribute[0] == 'T' && attribute[1] == '@')
             return [[NSString alloc] initWithBytes:(attribute + 3) length:strlen(attribute) - 4 encoding:NSUTF8StringEncoding ];
             }
     return @"";
 }
-
 
 +(NSDictionary *)classPropsFor:(Class)klass
 {

--- a/CIXClient/src/TableBase.m
+++ b/CIXClient/src/TableBase.m
@@ -389,28 +389,6 @@
     return text;
 }
 
-#if RETURN_CHAR_STAR
-static const char * getPropertyType(objc_property_t property)
-{
-    const char *attributes = property_getAttributes(property);
-
-    char buffer[1 + strlen(attributes)];
-    strcpy(buffer, attributes);
-    char *state = buffer, *attribute;
-    while ((attribute = strsep(&state, ",")) != NULL)
-    {
-        if (attribute[0] == 'T' && attribute[1] != '@')
-            return (const char *)[[NSData dataWithBytes:(attribute + 1) length:strlen(attribute) - 1] bytes];
-        
-        if (attribute[0] == 'T' && attribute[1] == '@' && strlen(attribute) == 2)
-            return "id";
-            
-        if (attribute[0] == 'T' && attribute[1] == '@')
-            return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
-    }
-    return "";
-}
-#else
 NSString * getPropertyType(objc_property_t property)
 {
     const char *attributes = property_getAttributes(property);
@@ -421,18 +399,16 @@ NSString * getPropertyType(objc_property_t property)
     while ((attribute = strsep(&state, ",")) != NULL)
     {
         if (attribute[0] == 'T' && attribute[1] != '@')
-            // return (const char *)[[NSData dataWithBytes:(attribute + 1) length:strlen(attribute) - 1] bytes];
             return [[NSString alloc] initWithBytes:(attribute + 1) length:strlen(attribute) - 1 encoding:NSUTF8StringEncoding ];
         if (attribute[0] == 'T' && attribute[1] == '@' && strlen(attribute) == 2)
             return @"id";
         
         if (attribute[0] == 'T' && attribute[1] == '@')
-            // return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
             return [[NSString alloc] initWithBytes:(attribute + 3) length:strlen(attribute) - 4 encoding:NSUTF8StringEncoding ];
             }
     return @"";
 }
-#endif
+
 
 +(NSDictionary *)classPropsFor:(Class)klass
 {
@@ -449,9 +425,8 @@ NSString * getPropertyType(objc_property_t property)
         const char *propName = property_getName(property);
         if (propName != NULL)
         {
-      //      const char *propType = getPropertyType(property);
             NSString *propertyName = [NSString stringWithUTF8String:propName];
-            NSString *propertyType = getPropertyType(property);  // [NSString stringWithUTF8String:propType];
+            NSString *propertyType = getPropertyType(property);
             results[propertyName] = propertyType;
         }
     }

--- a/CIXClient/src/TableBase.m
+++ b/CIXClient/src/TableBase.m
@@ -400,12 +400,13 @@ static NSString * getPropertyType(objc_property_t property)
     {
         if (attribute[0] == 'T' && attribute[1] != '@')
             return [[NSString alloc] initWithBytes:(attribute + 1) length:strlen(attribute) - 1 encoding:NSUTF8StringEncoding ];
+
         if (attribute[0] == 'T' && attribute[1] == '@' && strlen(attribute) == 2)
             return @"id";
 
         if (attribute[0] == 'T' && attribute[1] == '@')
             return [[NSString alloc] initWithBytes:(attribute + 3) length:strlen(attribute) - 4 encoding:NSUTF8StringEncoding ];
-            }
+    }
     return @"";
 }
 


### PR DESCRIPTION
This bug was found with the memory analysers.

cix:cix.beta/cixreadermac:1695

Using Xcode 8.2.1 as before.

This time I set 
Malloc Scribble, Malloc Guard Edges, Guard Malloc
and Zombie Objects for the Run scheme diagnostics.

This results in EXC_BAD_ACCESS at line
430 in TableBase.m